### PR TITLE
Initializing new bodies with angle; bug fix with undefined body

### DIFF
--- a/p2-integration.js
+++ b/p2-integration.js
@@ -162,11 +162,11 @@ P2World.prototype.postUpdate = function(dt) {
     var shape, shapes, numShapes;
     var entity, pos;
 
-    bodies = this.world.bodies;
-    numBodies = bodies.length;
-
     // Update the simulation
     this.world.step(1 / 60, dt, this.maxSubSteps);
+
+    bodies = this.world.bodies;
+    numBodies = bodies.length;
 
     // Set the transforms of entities from dynamic and kinematic bodies
     for (i = 0; i < numBodies; i++) {

--- a/p2-integration.js
+++ b/p2-integration.js
@@ -128,15 +128,19 @@ P2World.prototype.initialize = function() {
     });
     this.app.on('p2:addBody', function (body) {
         var pos = body.entity.getPosition();
+        var rot = body.entity.getEulerAngles();
         switch (self.axes) {
             case 1:
                 body.position = [ pos.x, pos.y ];
+                body.angle = rot.z * Math.PI / 180;
                 break;
             case 2:
                 body.position = [ pos.x, -pos.z ];
+                body.angle = rot.y * Math.PI / 180;
                 break;
             case 3:
                 body.position = [ -pos.z, pos.y ];
+                body.angle = rot.x * Math.PI / 180;
                 break;
         }
         world.addBody(body);


### PR DESCRIPTION
Chore: initializing new world bodies with angle value from Entity rotation.

Bug fix: using world.bodies remaining after world.step in world postUpdate, preventing bug where bodies removed in postStep are then undefined in script postUpdate.